### PR TITLE
Add SwiftUIFormApp example package

### DIFF
--- a/SwiftUIFormApp/Package.swift
+++ b/SwiftUIFormApp/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "SwiftUIFormApp",
+    platforms: [
+        .iOS(.v14),
+        .macCatalyst(.v14)
+    ],
+    products: [
+        .executable(name: "SwiftUIFormApp", targets: ["SwiftUIFormApp"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "SwiftUIFormApp",
+            path: "Sources/SwiftUIFormApp"
+        ),
+        .testTarget(
+            name: "SwiftUIFormAppTests",
+            dependencies: ["SwiftUIFormApp"],
+            path: "Tests/SwiftUIFormAppTests"
+        )
+    ]
+)

--- a/SwiftUIFormApp/README.md
+++ b/SwiftUIFormApp/README.md
@@ -1,0 +1,9 @@
+# SwiftUIFormApp
+
+A simple SwiftUI-based Google Form clone packaged as a Swift Package. Open `Package.swift` in Xcode 13 or later and build for either iOS 14+ or Mac Catalyst.
+
+Default admin credentials:
+- **Username:** `admin`
+- **Password:** `$uper@dmin`
+
+The password is stored in the local SQLite database as a SHA256 hash via `CryptoKit`.

--- a/SwiftUIFormApp/Sources/SwiftUIFormApp/AdminDashboardView.swift
+++ b/SwiftUIFormApp/Sources/SwiftUIFormApp/AdminDashboardView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Dashboard listing all entries with ability to edit or delete
+struct AdminDashboardView: View {
+    @Environment(\.presentationMode) private var presentationMode
+    @StateObject private var entryViewModel = EntryViewModel()
+    @State private var selectedEntry: Entry?
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(entryViewModel.entries) { entry in
+                    Button(action: { selectedEntry = entry }) {
+                        HStack {
+                            Text("#\(entry.id)")
+                            VStack(alignment: .leading) {
+                                Text(entry.name)
+                                Text(entry.assetTag).font(.caption)
+                            }
+                        }
+                    }
+                }
+                .onDelete { indexSet in
+                    indexSet.map { entryViewModel.entries[$0].id }.forEach(entryViewModel.delete)
+                }
+            }
+            .sheet(item: $selectedEntry) { entry in
+                EditEntryView(entry: entry) { updated in
+                    entryViewModel.update(entry: updated)
+                }
+            }
+            .navigationTitle("Admin Dashboard")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Logout") { presentationMode.wrappedValue.dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/SwiftUIFormApp/Sources/SwiftUIFormApp/AdminLoginView.swift
+++ b/SwiftUIFormApp/Sources/SwiftUIFormApp/AdminLoginView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Login view for admin access
+struct AdminLoginView: View {
+    @Environment(\.presentationMode) private var presentationMode
+    @StateObject private var viewModel = AdminViewModel()
+    @State private var username = ""
+    @State private var password = ""
+
+    var onDismiss: (() -> Void)?
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Username", text: $username)
+                SecureField("Password", text: $password)
+                Button("Login") {
+                    viewModel.login(username: username, password: password)
+                    if viewModel.isLoggedIn {
+                        presentationMode.wrappedValue.dismiss()
+                        onDismiss?()
+                    }
+                }
+                if let error = viewModel.loginError {
+                    Text(error).foregroundColor(.red)
+                }
+            }
+            .navigationTitle("Admin Login")
+        }
+    }
+}

--- a/SwiftUIFormApp/Sources/SwiftUIFormApp/AdminViewModel.swift
+++ b/SwiftUIFormApp/Sources/SwiftUIFormApp/AdminViewModel.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Combine
+
+/// View model handling admin authentication state
+final class AdminViewModel: ObservableObject {
+    @Published var isLoggedIn = false
+    @Published var loginError: String?
+
+    /// Validate credentials using DatabaseManager
+    func login(username: String, password: String) {
+        if DatabaseManager.shared.validateAdminCredentials(username: username, password: password) {
+            isLoggedIn = true
+            loginError = nil
+        } else {
+            loginError = "Invalid credentials"
+        }
+    }
+
+    /// Logout current admin
+    func logout() {
+        isLoggedIn = false
+    }
+}

--- a/SwiftUIFormApp/Sources/SwiftUIFormApp/ContentView.swift
+++ b/SwiftUIFormApp/Sources/SwiftUIFormApp/ContentView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// Landing page showing form submission and list of entries
+struct ContentView: View {
+    @State private var name = ""
+    @State private var assetTag = ""
+    @State private var alertMessage: String?
+    @State private var showAdminLogin = false
+
+    @StateObject private var viewModel = EntryViewModel()
+
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading) {
+                Form {
+                    TextField("Name", text: $name)
+                    TextField("Asset Tag", text: $assetTag)
+                    Button("Submit") { submit() }
+                }
+                .alert(isPresented: Binding(get: { alertMessage != nil }, set: { _ in alertMessage = nil })) {
+                    Alert(title: Text(alertMessage ?? ""))
+                }
+
+                List(viewModel.entries) { entry in
+                    VStack(alignment: .leading) {
+                        Text(entry.name)
+                        Text(entry.assetTag).font(.caption)
+                    }
+                }
+                Button("Login as Admin") { showAdminLogin = true }
+                    .padding()
+            }
+            .navigationTitle("SwiftUIFormApp")
+            .sheet(isPresented: $showAdminLogin) {
+                AdminLoginView() {
+                    viewModel.loadEntries()
+                }
+            }
+        }
+    }
+
+    /// Validate fields and submit entry
+    private func submit() {
+        guard !name.isEmpty, !assetTag.isEmpty else {
+            alertMessage = "Fields cannot be empty"
+            return
+        }
+
+        guard !DatabaseManager.shared.entryExists(name: name, assetTag: assetTag) else {
+            alertMessage = "Entry already exists"
+            return
+        }
+
+        DatabaseManager.shared.insertEntry(name: name, assetTag: assetTag)
+        name = ""
+        assetTag = ""
+        viewModel.loadEntries()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/SwiftUIFormApp/Sources/SwiftUIFormApp/DatabaseManager.swift
+++ b/SwiftUIFormApp/Sources/SwiftUIFormApp/DatabaseManager.swift
@@ -1,0 +1,178 @@
+import Foundation
+import SQLite3
+import CryptoKit
+
+/// Singleton responsible for managing the SQLite database
+final class DatabaseManager {
+    static let shared = DatabaseManager()
+
+    private let dbURL: URL
+    private var db: OpaquePointer?
+
+    private init() {
+        // Store database in Documents directory
+        let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        dbURL = paths[0].appendingPathComponent("form.sqlite")
+        openDatabase()
+        createTables()
+        insertDefaultAdminIfNeeded()
+    }
+
+    deinit {
+        sqlite3_close(db)
+    }
+
+    /// Open or create the SQLite database
+    private func openDatabase() {
+        if sqlite3_open(dbURL.path, &db) != SQLITE_OK {
+            print("Unable to open database at \(dbURL.path)")
+        }
+    }
+
+    /// Create entries and admins tables
+    private func createTables() {
+        let createEntries = """
+            CREATE TABLE IF NOT EXISTS entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT,
+                assetTag TEXT
+            );
+            """
+
+        let createAdmins = """
+            CREATE TABLE IF NOT EXISTS admins (
+                username TEXT PRIMARY KEY,
+                password TEXT
+            );
+            """
+
+        if sqlite3_exec(db, createEntries, nil, nil, nil) != SQLITE_OK {
+            print("Failed to create entries table")
+        }
+
+        if sqlite3_exec(db, createAdmins, nil, nil, nil) != SQLITE_OK {
+            print("Failed to create admins table")
+        }
+    }
+
+    /// Insert default admin credentials if not already present
+    private func insertDefaultAdminIfNeeded() {
+        let query = "SELECT username FROM admins WHERE username = ?"
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, "admin", -1, nil)
+            if sqlite3_step(statement) != SQLITE_ROW {
+                sqlite3_finalize(statement)
+                insertAdmin(username: "admin", password: "$uper@dmin")
+                return
+            }
+        }
+        sqlite3_finalize(statement)
+    }
+
+    /// Insert an admin with hashed password
+    private func insertAdmin(username: String, password: String) {
+        let insert = "INSERT INTO admins (username, password) VALUES (?, ?)"
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, insert, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (username as NSString).utf8String, -1, nil)
+            let hashed = SHA256.hash(data: Data(password.utf8)).compactMap { String(format: "%02x", $0) }.joined()
+            sqlite3_bind_text(statement, 2, (hashed as NSString).utf8String, -1, nil)
+            if sqlite3_step(statement) != SQLITE_DONE {
+                print("Failed to insert admin")
+            }
+        }
+        sqlite3_finalize(statement)
+    }
+
+    // MARK: Entry CRUD
+
+    func insertEntry(name: String, assetTag: String) {
+        let insert = "INSERT INTO entries (name, assetTag) VALUES (?, ?)"
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, insert, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (name as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(statement, 2, (assetTag as NSString).utf8String, -1, nil)
+            if sqlite3_step(statement) != SQLITE_DONE {
+                print("Failed to insert entry")
+            }
+        }
+        sqlite3_finalize(statement)
+    }
+
+    func fetchEntries() -> [Entry] {
+        var results: [Entry] = []
+        let query = "SELECT id, name, assetTag FROM entries ORDER BY id DESC"
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            while sqlite3_step(statement) == SQLITE_ROW {
+                let id = sqlite3_column_int64(statement, 0)
+                let name = String(cString: sqlite3_column_text(statement, 1))
+                let assetTag = String(cString: sqlite3_column_text(statement, 2))
+                results.append(Entry(id: Int(id), name: name, assetTag: assetTag))
+            }
+        }
+        sqlite3_finalize(statement)
+        return results
+    }
+
+    func updateEntry(_ entry: Entry) {
+        let update = "UPDATE entries SET name = ?, assetTag = ? WHERE id = ?"
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, update, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (entry.name as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(statement, 2, (entry.assetTag as NSString).utf8String, -1, nil)
+            sqlite3_bind_int(statement, 3, Int32(entry.id))
+            if sqlite3_step(statement) != SQLITE_DONE {
+                print("Failed to update entry")
+            }
+        }
+        sqlite3_finalize(statement)
+    }
+
+    func deleteEntry(id: Int) {
+        let delete = "DELETE FROM entries WHERE id = ?"
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, delete, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_int(statement, 1, Int32(id))
+            if sqlite3_step(statement) != SQLITE_DONE {
+                print("Failed to delete entry")
+            }
+        }
+        sqlite3_finalize(statement)
+    }
+
+    // MARK: Admin
+
+    /// Validate admin credentials using SHA256
+    func validateAdminCredentials(username: String, password: String) -> Bool {
+        let query = "SELECT password FROM admins WHERE username = ?"
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else { return false }
+        sqlite3_bind_text(statement, 1, (username as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_ROW else { return false }
+        guard let cPassword = sqlite3_column_text(statement, 0) else { return false }
+        let storedHash = String(cString: cPassword)
+        let hash = SHA256.hash(data: Data(password.utf8)).compactMap { String(format: "%02x", $0) }.joined()
+        return storedHash == hash
+    }
+
+    /// Check if an entry with the same name and assetTag exists
+    func entryExists(name: String, assetTag: String) -> Bool {
+        let query = "SELECT 1 FROM entries WHERE name = ? AND assetTag = ?"
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else { return false }
+        sqlite3_bind_text(statement, 1, (name as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 2, (assetTag as NSString).utf8String, -1, nil)
+        return sqlite3_step(statement) == SQLITE_ROW
+    }
+}
+
+/// Simple model used by view models
+struct Entry: Identifiable, Equatable {
+    let id: Int
+    var name: String
+    var assetTag: String
+}

--- a/SwiftUIFormApp/Sources/SwiftUIFormApp/EditEntryView.swift
+++ b/SwiftUIFormApp/Sources/SwiftUIFormApp/EditEntryView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// View used to edit an entry
+struct EditEntryView: View {
+    @Environment(\.presentationMode) private var presentationMode
+    @State private var entry: Entry
+    var onSave: (Entry) -> Void
+
+    init(entry: Entry, onSave: @escaping (Entry) -> Void) {
+        _entry = State(initialValue: entry)
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Name", text: $entry.name)
+                TextField("Asset Tag", text: $entry.assetTag)
+            }
+            .navigationTitle("Edit Entry")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") {
+                        onSave(entry)
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SwiftUIFormApp/Sources/SwiftUIFormApp/EntryViewModel.swift
+++ b/SwiftUIFormApp/Sources/SwiftUIFormApp/EntryViewModel.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Combine
+
+/// View model for user entries
+final class EntryViewModel: ObservableObject {
+    @Published private(set) var entries: [Entry] = []
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        loadEntries()
+    }
+
+    /// Load entries from the database
+    func loadEntries() {
+        entries = DatabaseManager.shared.fetchEntries()
+    }
+
+    /// Add a new entry if it doesn't already exist
+    func addEntry(name: String, assetTag: String) {
+        guard !name.isEmpty, !assetTag.isEmpty else { return }
+        guard !DatabaseManager.shared.entryExists(name: name, assetTag: assetTag) else { return }
+        DatabaseManager.shared.insertEntry(name: name, assetTag: assetTag)
+        loadEntries()
+    }
+
+    /// Update an existing entry
+    func update(entry: Entry) {
+        DatabaseManager.shared.updateEntry(entry)
+        loadEntries()
+    }
+
+    /// Delete an entry
+    func delete(id: Int) {
+        DatabaseManager.shared.deleteEntry(id: id)
+        loadEntries()
+    }
+}

--- a/SwiftUIFormApp/Sources/SwiftUIFormApp/FormApp.swift
+++ b/SwiftUIFormApp/Sources/SwiftUIFormApp/FormApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct FormApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/SwiftUIFormApp/Tests/SwiftUIFormAppTests/SwiftUIFormAppTests.swift
+++ b/SwiftUIFormApp/Tests/SwiftUIFormAppTests/SwiftUIFormAppTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import SwiftUIFormApp
+
+final class SwiftUIFormAppTests: XCTestCase {
+    func testDatabaseManagerInsert() {
+        // TODO: add database tests
+    }
+
+    func testEntryViewModelLoad() {
+        // TODO: add view model tests
+    }
+}


### PR DESCRIPTION
## Summary
- add SwiftUIFormApp package with SQLite persistence and admin workflow
- provide SwiftUI views and view models
- add default admin credentials and README instructions
- include unit test stubs

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*
- `swift test` *(fails: no such module 'SwiftUI')*